### PR TITLE
Cambio nombre estilo con guión

### DIFF
--- a/style.js
+++ b/style.js
@@ -44,6 +44,6 @@
 
 	BCEnglishOnlineStyle.prototype = _.extend({}, new blink.theme.styles.basic(), BCEnglishOnlineStyle.prototype);
 
-	blink.theme.styles.bcenglishonline = BCEnglishOnlineStyle;
+	blink.theme.styles['bc-englishonline'] = BCEnglishOnlineStyle;
 
 })( blink );


### PR DESCRIPTION
Este es el cambio. Si el estilo se crea con nombre con guión en la plataforma, hay que nombrarlo igual en el _style.js_; si no, cuando se comparan los nombres no se reconocen como el mismo estilo.